### PR TITLE
feat(app): implement multi-state gameweek views

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,3 @@
-Of course. This is the perfect time to create the public-facing README.md. It will serve as the front door to your project, explaining what it is and how to use it, while the CHARTER.md remains your internal strategic guide.
-
-Here is a complete, professional README.md file in Markdown, ready to be added to your project.
-
-code
-Markdown
-download
-content_copy
-expand_less
-
 # ViewXI
 
 ![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -50,7 +50,7 @@
             <div class="overflow-x-auto">
                 <table class="w-full text-left">
                     <thead class="bg-slate-700/50 text-slate-300 uppercase text-xs">
-                        <tr>
+                        <tr id="standard-table-header-row">
                             <th class="p-4">Player</th>
                             <th class="p-4 hidden md:table-cell">Position</th>
                             <th class="p-4">Status</th>
@@ -63,7 +63,48 @@
             </div>
         </div>
 
-        <!-- Correctly placed footer -->
+
+
+        <div id="planning-view-container" class="bg-slate-800/50 rounded-lg shadow-lg overflow-hidden hidden mt-8">
+            <div class="p-4 bg-slate-700/50 border-b border-slate-600">
+                <h2 class="text-xl font-bold">Planning for Gameweek <span id="planning-display-gameweek"></span></h2>
+                <p class="text-sm text-slate-400 mt-1">
+                    <span class="font-bold">NOTE:</span> Showing your final roster from GW<span id="planning-roster-gameweek"></span>. Transfers made for the upcoming gameweek are not yet visible.
+                </p>
+            </div>
+            <div class="overflow-x-auto">
+                <table class="w-full text-left">
+                    <thead class="bg-slate-700/50 text-slate-300 uppercase text-xs">
+                        <tr>
+                            <th class="p-4">Player</th>
+                            <th class="p-4">Status</th>
+                            <th class="p-4">Next 3 Fixtures</th> 
+                        </tr>
+                    </thead>
+                    <tbody id="planning-table-body" class="divide-y divide-slate-700"></tbody>
+                </table>
+            </div>
+            <div class="p-4 border-t border-slate-600 bg-slate-700/50">
+                <h3 class="font-bold text-lg text-white mb-3">Decision Support</h3>
+                <div class="flex flex-col sm:flex-row gap-3">
+                    
+                    <!-- Transfer Analysis Button -->
+                    <a href="https://www.allaboutfpl.com/" target="_blank" rel="noopener noreferrer" 
+                    class="flex-1 bg-slate-600 hover:bg-slate-500 text-white font-bold py-3 px-4 rounded-lg text-center no-underline transition-colors">
+                        🚀 Get Transfer Analysis
+                    </a>
+                    
+                    <!-- Captaincy Analysis Button -->
+                    <a href="https://fantasy.premierleague.com/the-scout" target="_blank" rel="noopener noreferrer"
+                    class="flex-1 bg-slate-600 hover:bg-slate-500 text-white font-bold py-3 px-4 rounded-lg text-center no-underline transition-colors">
+                        ©️ Get Captaincy Advice
+                    </a>
+
+                </div>
+            </div>
+        </div>
+
+        <!--footer -->
         <footer class="text-center mt-12 py-4">
             <button id="feedback-link" class="text-cyan-400 hover:underline text-sm">Got Feedback or an Idea?</button>
         </footer>
@@ -88,7 +129,7 @@
                 <h2 class="text-2xl font-bold text-white">Share Your Feedback</h2>
                 <button id="feedback-modal-close-button" class="text-slate-400 hover:text-white text-3xl">&times;</button>
             </div>
-            <!-- IMPORTANT: Remember to replace YOUR_UNIQUE_CODE with your real Formspree endpoint -->
+        
             <form id="feedback-form" action="https://formspree.io/f/mkgvbrqq" method="POST" class="p-6">
                 <textarea name="feedback" required placeholder="What's on your mind? Did you find a bug? Have an idea for a new feature?" rows="5" class="bg-slate-900 border border-slate-600 rounded-md p-2 w-full text-white focus:ring-2 focus:ring-cyan-400 focus:outline-none"></textarea>
                 <button type="submit" class="mt-4 w-full bg-gradient-to-r from-[#37003c] to-[#6a00ff] text-white font-bold py-2 px-6 rounded-md text-lg hover:opacity-90">Submit</button>
@@ -131,22 +172,49 @@
         // --- DOM Elements ---
         const teamIdInput = document.getElementById('team-id-input');
         const gameweekInput = document.getElementById('gameweek-input');
-        const displayGameweek = document.getElementById('display-gameweek');
         const submitButton = document.getElementById('submit-button');
         const loadingState = document.getElementById('loading-state');
         const errorContainer = document.getElementById('error-container');
+
+        // Standard + Historical View Elements
         const resultsContainer = document.getElementById('results-container');
+        const displayGameweek = document.getElementById('display-gameweek');
+        const standardTableHeaderRow = document.getElementById('standard-table-header-row');
         const playerTableBody = document.getElementById('player-table-body');
+
+        // Planning View Elements
+        const planningViewContainer = document.getElementById('planning-view-container');
+        const planningDisplayGameweek = document.getElementById('planning-display-gameweek');
+        const planningRosterGameweek = document.getElementById('planning-roster-gameweek');
+        const planningTableBody = document.getElementById('planning-table-body');
+
+        // Modal & Other Elements
         const modal = document.getElementById('player-modal');
         const modalCloseButton = document.getElementById('modal-close-button');
         const feedbackLink = document.getElementById('feedback-link');
         const feedbackModal = document.getElementById('feedback-modal');
-        const feedbackModalCloseButton = document.querySelector('#feedback-modal button'); // More specific selector
+        const feedbackModalCloseButton = document.getElementById('feedback-modal-close-button');
         const feedbackForm = document.getElementById('feedback-form');
         const howToLink = document.getElementById('how-to-link');
         const howToModal = document.getElementById('how-to-modal');
         const howToModalCloseButton = document.getElementById('how-to-modal-close-button');
+
         let fullPlayerData = [];
+
+        // --- Auto-fetch current gameweek on page load ---
+        const initializeView = async () => {
+            try {
+                const response = await fetch('http://localhost:8001/gameweek_status'); // Use your local backend port
+                if (!response.ok) return;
+                const data = await response.json();
+                if (data.next_gameweek) {
+                    gameweekInput.value = data.next_gameweek;
+                }
+            } catch (error) {
+                console.error("Could not fetch gameweek status:", error);
+            }
+        };
+        document.addEventListener('DOMContentLoaded', initializeView);
 
         // --- Input Validation ---
         const preventNegativeInput = (event) => {
@@ -155,9 +223,138 @@
         teamIdInput.addEventListener('input', preventNegativeInput);
         gameweekInput.addEventListener('input', preventNegativeInput);
 
+        // --- Main API Call Function ---
+        const fetchTeamData = async () => {
+            const teamId = teamIdInput.value;
+            const gameWeek = gameweekInput.value;
+            if (!teamId || !gameWeek) {
+                showError("Please enter both a Team ID and a Gameweek.");
+                return;
+            }
+            submitButton.disabled = true;
+            loadingState.classList.remove('hidden');
+            errorContainer.classList.add('hidden');
+            resultsContainer.classList.add('hidden');
+            planningViewContainer.classList.add('hidden');
+
+            try {
+                const apiUrl = `http://localhost:8001/get_team_details?team_id=${teamId}&game_week=${gameWeek}`; // Use your local backend port
+                const response = await fetch(apiUrl);
+                if (!response.ok) {
+                    const errorData = await response.json();
+                    throw new Error(errorData.detail || `An error occurred: ${response.statusText}`);
+                }
+                const data = await response.json();
+                fullPlayerData = data.players || [];
+
+                if (data.view_mode === "planning") {
+                    renderPlanningView(data);
+                } else {
+                    renderStandardView(data);
+                }
+            } catch (error) {
+                showError(error.message);
+            } finally {
+                submitButton.disabled = false;
+                loadingState.classList.add('hidden');
+            }
+        };
+
+        // --- UI Rendering Functions ---
+        function renderStandardView(data) {
+            if (!data.players || data.players.length === 0) {
+                showError(`No team data found for Gameweek ${gameweekInput.value}.`);
+                return;
+            }
+            const isLiveView = data.players[0].start_certainty !== null;
+            displayGameweek.textContent = gameweekInput.value;
+            renderTableHeaders(isLiveView);
+            playerTableBody.innerHTML = '';
+            const positionOrder = { "GKP": 1, "DEF": 2, "MID": 3, "FWD": 4 };
+            data.players.sort((a, b) => positionOrder[a.position] - positionOrder[b.position]);
+            data.players.forEach(player => {
+                const row = document.createElement('tr');
+                row.className = 'hover:bg-slate-700/50';
+                let cells = `
+                    <td class="p-4">
+                        <div class="flex items-center gap-3">
+                            <img src="${player.photo_url}" alt="${player.web_name}" class="w-10 h-10 rounded-full border-2 border-slate-600" onerror="this.onerror=null;this.src='https://fantasy.premierleague.com/dist/img/shirts/standard/shirt_0-110.png';">
+                            <button class="font-bold text-lg text-cyan-400 hover:underline" data-player-id="${player.element}">${player.web_name}</button>
+                        </div>
+                    </td>
+                    <td class="p-4 text-slate-300 hidden md:table-cell">${player.position}</td>
+                `;
+
+                if (isLiveView) {
+                    cells += `
+                        <td class="p-4 font-semibold">${renderStatus(player.player_status)}</td>
+                        <td class="p-4">${renderCertainty(player.start_certainty)}</td>
+                        <td class="p-4">${renderFixture(player.next_opponent_name, player.next_opponent_difficulty)}</td>
+                    `;
+                } else { // Historical View
+                    cells += `
+                        <td class="p-4">${renderResult(player)}</td>
+                        <td class="p-4 text-center">${player.event_points ?? 'N/A'}</td>
+                        <td class="p-4 text-center hidden md:table-cell">${player.bps ?? 'N/A'}</td>
+                    `;
+                }
+                row.innerHTML = cells;
+                playerTableBody.appendChild(row);
+            });
+            resultsContainer.classList.remove('hidden');
+        }
+
+        function renderPlanningView(data) {
+            planningDisplayGameweek.textContent = data.requested_gameweek;
+            planningRosterGameweek.textContent = data.roster_gameweek;
+            planningTableBody.innerHTML = '';
+            const positionOrder = { "GKP": 1, "DEF": 2, "MID": 3, "FWD": 4 };
+            data.players.sort((a, b) => positionOrder[a.position] - positionOrder[b.position]);
+            data.players.forEach(player => {
+                const row = document.createElement('tr');
+                row.className = 'hover:bg-slate-700/50';
+                row.innerHTML = `
+                    <td class="p-4">
+                        <div class="flex items-center gap-3">
+                            <img src="${player.photo_url}" alt="${player.web_name}" class="w-10 h-10 rounded-full border-2 border-slate-600" onerror="this.onerror=null;this.src='https://fantasy.premierleague.com/dist/img/shirts/standard/shirt_0-110.png';">
+                            <button class="font-bold text-lg text-cyan-400 hover:underline" data-player-id="${player.element}">${player.web_name}</button>
+                        </div>
+                    </td>
+                    <td class="p-4 font-semibold">${renderStatus(player.player_status)}</td>
+                    <td class="p-4">
+                        <div class="flex items-center gap-2 flex-wrap">
+                            ${player.next_3_fixtures.map(fixture => renderFixture(fixture.opponent_name, fixture.difficulty)).join('')}
+                        </div>
+                    </td>
+                `;
+                planningTableBody.appendChild(row);
+            });
+            planningViewContainer.classList.remove('hidden');
+        }
+
+        function renderTableHeaders(isLive) {
+            if (isLive) {
+                standardTableHeaderRow.innerHTML = `
+                    <th class="p-4">Player</th>
+                    <th class="p-4 hidden md:table-cell">Position</th>
+                    <th class="p-4">Status</th>
+                    <th class="p-4">Start Certainty</th>
+                    <th class="p-4">Next Fixture</th> 
+                `;
+            } else {
+                standardTableHeaderRow.innerHTML = `
+                    <th class="p-4">Player</th>
+                    <th class="p-4 hidden md:table-cell">Position</th>
+                    <th class="p-4">Result</th>
+                    <th class="p-4 text-center">Points</th>
+                    <th class="p-4 text-center hidden md:table-cell">BPS</th> 
+                `;
+            }
+        }
+        
         // --- Visual Helper Functions ---
         const renderStatus = (status) => {
-            let icon = ''; let colorClass = '';
+            let icon = '', colorClass = '';
             switch (status) {
                 case 'Available':   icon = '✅'; colorClass = 'text-green-400'; break;
                 case 'Doubtful':    icon = '🟡'; colorClass = 'text-yellow-400'; break;
@@ -167,96 +364,87 @@
             }
             return `<div class="flex items-center gap-2"><span class="text-xl">${icon}</span> <span class="${colorClass}">${status}</span></div>`;
         };
+
         const renderCertainty = (certainty) => {
+            if (!certainty) return 'N/A';
             let icon = '';
             switch (certainty.split('(')[0].trim()) {
-                case 'Nailed On': icon = '🔥'; break;
+                case 'High': icon = '🔥'; break;
                 case 'Likely Starter': icon = '✅'; break;
                 case 'Doubtful': icon = '🟡'; break;
                 case 'Rotation Risk': icon = '😐'; break;
                 case 'Bench Player': icon = '❄️'; break;
-                case 'Unavailable': icon = '❌'; break;
                 default: icon = 'ℹ️';
             }
             return `<div class="flex items-center gap-2"><span class="text-xl">${icon}</span> <span>${certainty}</span></div>`;
         };
 
-        // --- Main API Call Function ---
-        const fetchTeamData = async () => {
-            const teamId = teamIdInput.value; const gameWeek = gameweekInput.value;
-            if (!teamId || !gameWeek) { showError("Please enter both a Team ID and a Gameweek."); return; }
-            submitButton.disabled = true; loadingState.classList.remove('hidden'); errorContainer.classList.add('hidden'); resultsContainer.classList.add('hidden');
-            displayGameweek.textContent = gameWeek;
-            try {
-                const apiUrl = `https://view-ix-api.onrender.com/get_team_details?team_id=${teamId}&game_week=${gameWeek}`;
-                const response = await fetch(apiUrl);
-                if (!response.ok) { const errorData = await response.json(); throw new Error(errorData.detail || `An error occurred: ${response.statusText}`); }
-                const data = await response.json(); fullPlayerData = data.players || [];
-                if (fullPlayerData.length === 0) { showError(`No team data found for Gameweek ${gameWeek}. The gameweek may not be active yet.`); }
-                else { renderTable(fullPlayerData); resultsContainer.classList.remove('hidden'); }
-            } catch (error) { showError(error.message); }
-            finally { submitButton.disabled = false; loadingState.classList.add('hidden'); }
+        const renderFixture = (opponentName, difficulty) => {
+            let colorClass = 'bg-slate-600';
+            if (difficulty <= 2) colorClass = 'bg-green-500';
+            else if (difficulty === 3) colorClass = 'bg-yellow-400';
+            else if (difficulty >= 4) colorClass = 'bg-red-500';
+            return `<div class="flex items-center gap-2 p-1 rounded-md"><span class="w-4 h-4 rounded-full ${colorClass}"></span><span class="text-slate-300">${opponentName}</span></div>`;
         };
 
-        // --- UI Rendering Functions ---
-        const renderTable = (players) => {
-            playerTableBody.innerHTML = ''; const positionOrder = { "GKP": 1, "DEF": 2, "MID": 3, "FWD": 4 };
-            players.sort((a, b) => positionOrder[a.position] - positionOrder[b.position]);
-            players.forEach(player => {
-                const row = document.createElement('tr'); row.className = 'hover:bg-slate-700/50';
-                const nameCell = document.createElement('td'); nameCell.className = 'p-4';
-                const playerContainer = document.createElement('div'); playerContainer.className = 'flex items-center gap-3';
-                const playerImage = document.createElement('img');
-                playerImage.src = player.photo_url;
-                playerImage.alt = player.web_name; playerImage.className = 'w-10 h-10 rounded-full border-2 border-slate-600';
-                playerImage.onerror = function() { this.onerror = null; this.src = 'https://fantasy.premierleague.com/dist/img/shirts/standard/shirt_0-110.png'; };
-                const nameButton = document.createElement('button'); nameButton.className = 'font-bold text-lg text-cyan-400 hover:underline'; nameButton.textContent = player.web_name; nameButton.dataset.playerId = player.element;
-                playerContainer.appendChild(playerImage); playerContainer.appendChild(nameButton); nameCell.appendChild(playerContainer);
-                const posCell = document.createElement('td'); posCell.className = 'p-4 text-slate-300 hidden md:table-cell'; posCell.textContent = player.position;
-                const statusCell = document.createElement('td'); statusCell.className = 'p-4 font-semibold'; statusCell.innerHTML = renderStatus(player.player_status);
-                const certaintyCell = document.createElement('td'); certaintyCell.className = 'p-4'; certaintyCell.innerHTML = renderCertainty(player.start_certainty);
-                const fixtureCell = document.createElement('td'); const difficulty = player.next_opponent_difficulty;
-                let colorClass = 'bg-slate-600'; if (difficulty <= 2) colorClass = 'bg-green-500'; else if (difficulty === 3) colorClass = 'bg-yellow-400'; else if (difficulty >= 4) colorClass = 'bg-red-500';
-                fixtureCell.innerHTML = `<div class="flex items-center gap-2"><span class="w-4 h-4 rounded-full ${colorClass}"></span><span class="text-slate-300">${player.next_opponent_name}</span></div>`;
-                row.append(nameCell, posCell, statusCell, certaintyCell, fixtureCell); playerTableBody.appendChild(row);
-            });
+        const renderResult = (player) => {
+            if (player.opponent === null) return 'N/A';
+            return `
+                <div class="font-semibold">${player.opponent}</div>
+                <div class="text-sm text-slate-400">${player.player_team_score} - ${player.opponent_team_score}</div>
+            `;
         };
-        const showError = (message) => { errorContainer.textContent = `Error: ${message}`; errorContainer.classList.remove('hidden'); };
+
+        const showError = (message) => {
+            errorContainer.textContent = `Error: ${message}`;
+            errorContainer.classList.remove('hidden');
+        };
+
+        // --- Modal Functions ---
         const showModal = (player) => {
             document.getElementById('modal-player-name').textContent = player.web_name;
             const modalGrid = document.getElementById('modal-details-grid');
             const details = {
-                'Fitness': renderStatus(player.player_status), 'Start Certainty': renderCertainty(player.start_certainty),
-                'Injury News': `<span class="text-lg">${player.player_news}</span>`,
-                'Next Opponent': `<div class="flex items-center gap-2"><span class="w-4 h-4 rounded-full ${player.next_opponent_difficulty <= 2 ? 'bg-green-500' : player.next_opponent_difficulty === 3 ? 'bg-yellow-400' : 'bg-red-500'}"></span><span class="text-lg">${player.next_opponent_name}</span></div>`,
-                'Position': `<span class="text-lg">${player.position}</span>`, 'Cost': `<span class="text-lg">£${(player.now_cost / 10).toFixed(1)}m</span>`,
-                'Goals Scored': `<span class="text-lg">${player.goals_scored}</span>`, 'Assists': `<span class="text-lg">${player.assists}</span>`,
+                'Position': `<span class="text-lg">${player.position}</span>`,
+                'Cost': `<span class="text-lg">£${(player.now_cost / 10).toFixed(1)}m</span>`,
+                'Total Goals (Season)': `<span class="text-lg">${player.goals_scored ?? 'N/A'}</span>`,
+                'Total Assists (Season)': `<span class="text-lg">${player.assists ?? 'N/A'}</span>`,
             };
+            if (player.player_status !== null) {
+                details['Fitness'] = renderStatus(player.player_status);
+                details['Injury News'] = `<span class="text-lg">${player.player_news || "No news"}</span>`;
+            }
+            if (player.start_certainty !== null) {
+                details['Start Certainty'] = renderCertainty(player.start_certainty);
+            }
+            if (player.event_points !== null) {
+                details['Gameweek Points'] = `<span class="text-lg">${player.event_points}</span>`;
+                details['Bonus Points (BPS)'] = `<span class="text-lg">${player.bps}</span>`;
+            }
+            if (player.defensive_contribution_per_90 !== null) {
+                details['Def. Actions/90'] = `<span class="text-lg">${player.defensive_contribution_per_90}</span>`;
+            }
+            if (player.opponent !== null) {
+                details['Result'] = renderResult(player);
+            }
             modalGrid.innerHTML = Object.entries(details).map(([key, value]) => `<div class="bg-slate-700/50 p-4 rounded-md"><h3 class="text-slate-400 text-sm font-bold mb-1">${key}</h3>${value}</div>`).join('');
             modal.classList.remove('hidden');
         };
+
         const hideModal = () => modal.classList.add('hidden');
         const showFeedbackModal = () => feedbackModal.classList.remove('hidden');
         const hideFeedbackModal = () => feedbackModal.classList.add('hidden');
-
         const showHowToModal = () => howToModal.classList.remove('hidden');
         const hideHowToModal = () => howToModal.classList.add('hidden');
 
         // --- Event Listeners ---
-
         howToLink.addEventListener('click', showHowToModal);
         howToModalCloseButton.addEventListener('click', hideHowToModal);
-        howToModal.addEventListener('click', (e) => {
-            // Close if the click is on the backdrop, not the content
-            if (e.target === howToModal) {
-                hideHowToModal();
-            }
-        });
-
+        howToModal.addEventListener('click', (e) => e.target === howToModal && hideHowToModal());
         submitButton.addEventListener('click', fetchTeamData);
         teamIdInput.addEventListener('keydown', (e) => e.key === 'Enter' && fetchTeamData());
         gameweekInput.addEventListener('keydown', (e) => e.key === 'Enter' && fetchTeamData());
-        playerTableBody.addEventListener('click', (e) => {
+        document.querySelector('.container').addEventListener('click', (e) => {
             const button = e.target.closest('button[data-player-id]');
             if (button) {
                 const player = fullPlayerData.find(p => p.element === parseInt(button.dataset.playerId, 10));
@@ -278,6 +466,7 @@
                 } else { alert('Oops! There was a problem submitting your form.'); }
             }).catch(() => alert('Oops! There was a problem submitting your form.'));
         });
+
+
     </script>
 </body>
-</html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -95,7 +95,7 @@
                     </a>
                     
                     <!-- Captaincy Analysis Button -->
-                    <a href="https://fantasy.premierleague.com/the-scout" target="_blank" rel="noopener noreferrer"
+                    <a href="https://allaboutfpl.com/category/captaincy-metrics/" target="_blank" rel="noopener noreferrer"
                     class="flex-1 bg-slate-600 hover:bg-slate-500 text-white font-bold py-3 px-4 rounded-lg text-center no-underline transition-colors">
                         ©️ Get Captaincy Advice
                     </a>
@@ -294,8 +294,6 @@
                 } else { // Historical View
                     cells += `
                         <td class="p-4">${renderResult(player)}</td>
-                        <td class="p-4 text-center">${player.event_points ?? 'N/A'}</td>
-                        <td class="p-4 text-center hidden md:table-cell">${player.bps ?? 'N/A'}</td>
                     `;
                 }
                 row.innerHTML = cells;
@@ -323,7 +321,7 @@
                     <td class="p-4 font-semibold">${renderStatus(player.player_status)}</td>
                     <td class="p-4">
                         <div class="flex items-center gap-2 flex-wrap">
-                            ${player.next_3_fixtures.map(fixture => renderFixture(fixture.opponent_name, fixture.difficulty)).join('')}
+                            ${player.upcoming_fixtures.map(fixture => renderFixture(fixture.opponent_name, fixture.difficulty)).join('')}
                         </div>
                     </td>
                 `;
@@ -339,15 +337,13 @@
                     <th class="p-4 hidden md:table-cell">Position</th>
                     <th class="p-4">Status</th>
                     <th class="p-4">Start Certainty</th>
-                    <th class="p-4">Next Fixture</th> 
+                    <th class="p-4">Opponent</th> 
                 `;
             } else {
                 standardTableHeaderRow.innerHTML = `
                     <th class="p-4">Player</th>
                     <th class="p-4 hidden md:table-cell">Position</th>
                     <th class="p-4">Result</th>
-                    <th class="p-4 text-center">Points</th>
-                    <th class="p-4 text-center hidden md:table-cell">BPS</th> 
                 `;
             }
         }
@@ -401,33 +397,60 @@
         };
 
         // --- Modal Functions ---
+
+
+
         const showModal = (player) => {
             document.getElementById('modal-player-name').textContent = player.web_name;
             const modalGrid = document.getElementById('modal-details-grid');
-            const details = {
-                'Position': `<span class="text-lg">${player.position}</span>`,
-                'Cost': `<span class="text-lg">£${(player.now_cost / 10).toFixed(1)}m</span>`,
-                'Total Goals (Season)': `<span class="text-lg">${player.goals_scored ?? 'N/A'}</span>`,
-                'Total Assists (Season)': `<span class="text-lg">${player.assists ?? 'N/A'}</span>`,
-            };
-            if (player.player_status !== null) {
-                details['Fitness'] = renderStatus(player.player_status);
-                details['Injury News'] = `<span class="text-lg">${player.player_news || "No news"}</span>`;
+            
+            // --- The Dynamic Details Object ---
+            let details = {}; // Start with an empty object
+
+            // --- Determine the View Mode ---
+            const isPlanningView = player.upcoming_fixtures !== undefined;
+            const isLiveView = player.start_certainty !== undefined; // <-- Our new, reliable fingerprint
+
+            if (isPlanningView) {
+                // --- PLANNING VIEW MODAL ---
+                details = {
+                    'Fitness': renderStatus(player.player_status),
+                    'Injury News': `<span class="text-lg">${player.player_news || "No news"}</span>`,
+                    'Start Certainty': renderCertainty(player.start_certainty),
+                    'Cost': `<span class="text-lg">£${(player.now_cost / 10).toFixed(1)}m</span>`,
+                    'Position': `<span class="text-lg">${player.position}</span>`,
+                    'Total Goals (Season)': `<span class="text-lg">${player.goals_scored ?? 'N/A'}</span>`,
+                    'Total Assists (Season)': `<span class="text-lg">${player.assists ?? 'N/A'}</span>`,
+                };
+            } else if (isLiveView) {
+                // --- LIVE VIEW MODAL ---
+                details = {
+                    //'Opponent': renderFixture(player.next_opponent_name, player.next_opponent_difficulty),
+                    'Result': renderResult(player),
+                    'Fitness': renderStatus(player.player_status),
+                    'Injury News': `<span class="text-lg">${player.player_news || "No news"}</span>`,
+                    'Start Certainty': renderCertainty(player.start_certainty),
+                    'Cost': `<span class="text-lg">£${(player.now_cost / 10).toFixed(1)}m</span>`,
+                    'Gameweek Points': `<span class="text-lg">${player.event_points ?? 'N/A'}</span>`,
+                    'Bonus Points (BPS)': `<span class="text-lg">${player.bps ?? 'N/A'}</span>`,
+                    'Position': `<span class="text-lg">${player.position}</span>`,
+                };
+            } else {
+                // --- HISTORICAL VIEW MODAL (Default) ---
+                details = {
+                    'Result': renderResult(player),
+                    'Cost': `<span class="text-lg">£${(player.now_cost / 10).toFixed(1)}m</span>`,
+                    'Position': `<span class="text-lg">${player.position}</span>`,
+                    'Total Goals (Season)': `<span class="text-lg">${player.goals_scored ?? 'N/A'}</span>`,
+                    'Total Assists (Season)': `<span class="text-lg">${player.assists ?? 'N/A'}</span>`,
+                };
             }
-            if (player.start_certainty !== null) {
-                details['Start Certainty'] = renderCertainty(player.start_certainty);
-            }
-            if (player.event_points !== null) {
-                details['Gameweek Points'] = `<span class="text-lg">${player.event_points}</span>`;
-                details['Bonus Points (BPS)'] = `<span class="text-lg">${player.bps}</span>`;
-            }
-            if (player.defensive_contribution_per_90 !== null) {
-                details['Def. Actions/90'] = `<span class="text-lg">${player.defensive_contribution_per_90}</span>`;
-            }
-            if (player.opponent !== null) {
-                details['Result'] = renderResult(player);
-            }
-            modalGrid.innerHTML = Object.entries(details).map(([key, value]) => `<div class="bg-slate-700/50 p-4 rounded-md"><h3 class="text-slate-400 text-sm font-bold mb-1">${key}</h3>${value}</div>`).join('');
+            
+            // --- Render the final object ---
+            modalGrid.innerHTML = Object.entries(details)
+                .map(([key, value]) => `<div class="bg-slate-700/50 p-4 rounded-md"><h3 class="text-slate-400 text-sm font-bold mb-1">${key}</h3>${value}</div>`)
+                .join('');
+                
             modal.classList.remove('hidden');
         };
 

--- a/main.py
+++ b/main.py
@@ -15,6 +15,7 @@ origins = [
     "https://view-ix.vercel.app",
     "http://127.0.0.1:8001",
     "http://localhost:8001",
+    "http://localhost:8000"
 ]
 
 app.add_middleware(
@@ -31,7 +32,6 @@ async def get_manager_team_details(team_id:int,game_week:int):
     gameweek_status= await get_gameweek_status()
     current_gameweek = gameweek_status.get("current_gameweek")
     
-    #manager_team_picks = await get_manager_team(team_id, game_week)
     bootstrap_data = await get_fpl_metadata_cached()
     fixtures_metadata = await get_fixtures()
 
@@ -41,13 +41,17 @@ async def get_manager_team_details(team_id:int,game_week:int):
 
     start_certainty = None
 
-
-    if not bootstrap_data: #or not fixtures_metadata:
+    if not bootstrap_data: 
         print("essential data source could not be retrieved from API")
-        raise HTTPException(status_code=503, detail="Could not retrieve core data from FPL API")
+        raise HTTPException(
+            status_code=503,
+            detail="Could not retrieve core data from FPL API"
+            )
         
     
     is_planning_view = game_week > current_gameweek
+    # is_live_view = game_week == current_gameweek
+    # is_historical_view = game_week < current_gameweek
     roster_gameweek = current_gameweek if is_planning_view else game_week
 
     manager_team_picks = await get_manager_team(team_id, roster_gameweek)
@@ -61,84 +65,80 @@ async def get_manager_team_details(team_id:int,game_week:int):
         if not player_details:
                 continue
         
-        team_id = player_details.get("team")
-        team_name = team_map.get(team_id)
-        position_id = player_details.get("element_type")
-        position = position_map.get(position_id, "UNK")
-        player_code=player_details.get("code",0)
-        photo_url = construct_player_image_url(player_code=player_code)
-        fpl_status = player_details.get("status", "u")
-        player_availability = map_player_status(fpl_status)
-        player_news = player_details.get("news","No news available")
+        base_player_data = {
+            **pick,
+            **player_details,
+            "team_name":team_map.get(player_details.get("team")),
+            "position": position_map.get(player_details.get("element_type")),
+            "photo_url":construct_player_image_url(player_code=player_details.get("code",0))
 
-        print(f"Accessing fixture difficulty for: {player_id}")
-        fixture_difficulty_list = await get_fixture_difficulty(
-            current_game_week=game_week,
-            player_id=player_id,
-            player_map=player_map,
-            team_map=team_map,
-            fixtures_metadata=fixtures_metadata
-            )
+        }
+               
 
         if is_planning_view:
-            player_data = {
-                    **pick,
-                    **player_details,
-                    "view_mode": "planning",
-                    "requested_gameweek": game_week,
-                    "roster_gameweek": roster_gameweek,
-                    "player_status": player_availability,
-                    "player_news": player_news,
-                    "team_name": team_name,
-                    "position": position,
-                    "next_3_fixtures":fixture_difficulty_list,
-                    "photo_url":photo_url
-                }
-            
-            player_obj = PlanningPlayerDetail(**player_data)
+            fixture_difficulty_list = await get_fixture_difficulty(
+                current_game_week=game_week,
+                player_id=player_id,
+                player_map=player_map,
+                team_map=team_map,
+                fixtures_metadata=fixtures_metadata
+            )
 
+            player_obj = PlanningPlayerDetail(
+                **base_player_data,
+                player_availability= map_player_status(player_details.get("status", "u")),
+                player_news = player_details.get("news","No news available"),
+                next_3_fixtures=fixture_difficulty_list
+            )
         else:
-            next_fixture = fixture_difficulty_list[0] if fixture_difficulty_list else {}
-            next_opponent_name = next_fixture.get("opponent_name","N/A")
-            next_opponent_difficulty = next_fixture.get('difficulty',0) 
+            player_obj_data = {**base_player_data}
 
-            #player_availability = map_player_status(fpl_status)
-            
+            if game_week == current_gameweek:
+                player_availability = map_player_status(player_details.get("status", "u"))
+                player_obj_data["player_status"]= player_availability
 
-            number_of_starts= player_details.get('starts',0)
-            start_ratio = number_of_starts/game_week if game_week > 0 else 0
-            
-            if player_availability == 'Unavailable' or player_availability == 'Suspended' or player_availability == 'Injured':
-                start_certainty = "Bench Player"
-            elif player_availability == 'Doubtful' and start_ratio >.60:
-                start_certainty = "Doubtful (but a regular starter)"
-            elif player_availability == 'Doubtful' and start_ratio <.60:
-                start_certainty = "Doubtful (and not a regular starter)"
-            elif player_availability == 'Available' and start_ratio >=.85:
-                start_certainty = "High"
-            elif player_availability == 'Available' and start_ratio >=.60:
-                start_certainty = "Likely Starter"
-            elif player_availability == 'Available' and start_ratio >=.30 and start_ratio <.60:
-                start_certainty = "Rotation Risk"
-            else:
-                start_certainty= "Bench Player"
-
-         
-            player_data ={
-                **pick,
-                **player_details,
-                "player_status": player_availability,
-                "player_news": player_news,
-                "start_certainty": start_certainty,
-                "team_name": team_name,
-                "position": position,
-                "next_opponent_name": next_opponent_name,
-                "next_opponent_difficulty": next_opponent_difficulty,
-                "photo_url":photo_url
-            }
+                number_of_starts= player_details.get('starts',0)
+                start_ratio = number_of_starts/game_week if game_week > 0 else 0
                 
-            player_obj = PlayerDetail(**player_data)
-        manager_team_details.append(player_obj)
+                if player_availability == 'Unavailable' or player_availability == 'Suspended' or player_availability == 'Injured':
+                    start_certainty = "Bench Player"
+                elif player_availability == 'Doubtful' and start_ratio >.60:
+                    start_certainty = "Doubtful (but a regular starter)"
+                elif player_availability == 'Doubtful' and start_ratio <.60:
+                    start_certainty = "Doubtful (and not a regular starter)"
+                elif player_availability == 'Available' and start_ratio >=.85:
+                    start_certainty = "High"
+                elif player_availability == 'Available' and start_ratio >=.60:
+                    start_certainty = "Likely Starter"
+                elif player_availability == 'Available' and start_ratio >=.30 and start_ratio <.60:
+                    start_certainty = "Rotation Risk"
+                else:
+                    start_certainty= "Bench Player"
+
+                player_obj_data["start_certainty"] = start_certainty
+                player_obj_data["event_points"] = player_details.get("event_points", 0)
+                player_obj_data["bps"] = player_details.get("bps", 0)
+                player_obj_data["defensive_contribution_per_90"] = player_details.get(
+                    "defensive_contribution_per_90", 0.0
+                    )
+            else:
+                fixture_list = await get_fixture_difficulty(game_week,
+                                                            player_id, 
+                                                            player_map, 
+                                                            team_map,
+                                                            fixtures_metadata
+                                                            )
+                
+                player_obj_data = {**base_player_data}
+
+                if fixture_list:
+                    historical_fixture = fixture_list[0]
+                    player_obj_data["opponent"] = historical_fixture.get("opponent_name")
+                    player_obj_data["player_team_score"] = historical_fixture.get("player_team_score")
+                    player_obj_data["opponent_team_score"] = historical_fixture.get("opponent_team_score")
+
+            player_obj = PlayerDetail(**player_obj_data)
+            manager_team_details.append(player_obj)
 
     if is_planning_view:
         return PlanningViewResponse(
@@ -148,56 +148,21 @@ async def get_manager_team_details(team_id:int,game_week:int):
         )
     else:
         return TeamDetailsResponse(players=manager_team_details)
-    
-
-
-
-
-    #     print(f"Successfully retrieved details for manager's team of {len(manager_team_details)} players.")
-    #     return TeamDetailsResponse(players=manager_team_details)
-    # elif game_week > current_gameweek:
-    #     manager_team_picks = await get_manager_team(team_id, current_gameweek)
-    #     for pick in manager_team_picks:
-    #         player_id = pick.get("element")
-    #         player_details = player_map.get(player_id)
-
-    #         if player_details:
-    #             print(f"Accessing fixture difficulty for: {player_id}")
-    #             fixture_difficulty_list = await get_fixture_difficulty(
-    #                 current_game_week=game_week,
-    #                 player_id=player_id,
-    #                 player_map=player_map,
-    #                 team_map=team_map,
-    #                 fixtures_metadata=fixtures_metadata
-    #                 )
-    #             team_id = player_details.get("team")
-    #             team_name = team_map.get(team_id)
-    #             position_id = player_details.get("element_type")
-    #             position = position_map.get(position_id, "UNK")
-
-    #             fpl_status = player_details.get("status", "u")
-    #             player_availability = map_player_status(fpl_status)
-    #             player_news = player_details.get("news","No news available")
-
-    #             player_code=player_details.get("code",0)
-    #             photo_url = construct_player_image_url(player_code=player_code)
-    #             print("photo_url:", photo_url)
-
-    #             combined_data=
-
-    #             return combined_data
                 
-
-
-
-
-
-
+                    
 
 @app.get("/gameweek_status")
 async def get_gameweek_status()->dict:
 
     fpl_metadata = await get_fpl_metadata_cached()
+
+    if not fpl_metadata:
+        raise HTTPException(
+            status_code=503,
+            detail="Could not retrieve core metadata from the FPL API. It may be temporarily down."
+        )
+
+
     events_list = fpl_metadata.get('events',[])
 
     gameweek_num=None
@@ -211,8 +176,6 @@ async def get_gameweek_status()->dict:
             if current_status == True:
                 gameweek_num = int(event.get('id'))
                 print(f"Current game week found")
-                # if game_week == gameweek_num:
-                #     print(f"User requested game week: {game_week}, is the current game week")
                 status['current_gameweek']= gameweek_num
                 status['previous_gameweek'] = gameweek_num -1
                 status['next_gameweek'] = gameweek_num +1
@@ -222,25 +185,4 @@ async def get_gameweek_status()->dict:
         except Exception as e:
             print(f"Failed to find current gameweek {e}")
             return {}
-
-    
-
-
-             
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    
-
-
+        

--- a/main.py
+++ b/main.py
@@ -114,6 +114,44 @@ async def get_manager_team_details(team_id:int,game_week:int):
     return TeamDetailsResponse(players=manager_team_details)
 
 
+@app.get("/gameweek_status")
+async def get_gameweek_status(game_week:int)->dict:
+
+    fpl_metadata = await get_fpl_metadata_cached()
+    events_list = fpl_metadata.get('events',[])
+
+    gameweek_num=None
+    status={}
+    #current_gameweek= None
+    #previous_gameweek = None
+    #next_gameweek=None
+
+    for event in events_list:
+        print(f"Attempting to retrieve current gameweek")
+        current_status = event.get("is_current")
+        if current_status == True:
+            gameweek_num = int(event.get('id'))
+            print(f"Current game week found")
+            if game_week == gameweek_num:
+                print(f"User requested game week: {game_week}, is the current game week")
+                status['current_gameweek']= game_week
+                status['previous_gameweek'] = game_week -1
+                status['next_gameweek'] = game_week+1
+                return status
+            else:
+                print(f"User requested game week: {game_week}, is not the current game week ")
+        else:
+            continue
+
+    
+
+
+             
+
+
+
+
+
 
 
 

--- a/src/fpl_api_scraper.py
+++ b/src/fpl_api_scraper.py
@@ -105,6 +105,7 @@ async def get_fixture_difficulty(
    
    player_team_id = player_info.get("team")
    next_three_fixtures= [current_game_week+1, current_game_week+2, current_game_week+3]
+   
    fixture_difficulty=[]
 
    for match in fixtures_metadata:
@@ -116,23 +117,31 @@ async def get_fixture_difficulty(
 
            if away_team_id==player_team_id:
                difficulty=match.get('team_h_difficulty')
+               player_team_score = match.get('team_a_score')
+               opponent_team_score = match.get('team_h_score')
                opponent_name=team_map.get(home_team_id)
                is_home_game= False
                fixture_difficulty.append({
                    "opponent_name": f"{opponent_name} (A)",
                    "difficulty": difficulty,
                    "is_home": is_home_game,
-                   "gameweek":game_week
+                   "gameweek":game_week,
+                   "player_team_score":player_team_score,
+                   "opponent_team_score": opponent_team_score
                    })
            elif home_team_id==player_team_id:
                difficulty=match.get('team_a_difficulty')
                opponent_name=team_map.get(away_team_id)
+               player_team_score = match.get('team_h_score')
+               opponent_team_score = match.get('team_a_score')
                is_home_game= True
                fixture_difficulty.append({
                    "opponent_name": f"{opponent_name} (H)",
                    "difficulty": difficulty,
                    "is_home": is_home_game,
-                   "gameweek":game_week
+                   "gameweek":game_week,
+                   "player_team_score":player_team_score,
+                   "opponent_team_score": opponent_team_score
                    })
 
    return fixture_difficulty

--- a/src/fpl_api_scraper.py
+++ b/src/fpl_api_scraper.py
@@ -104,14 +104,14 @@ async def get_fixture_difficulty(
        return []
    
    player_team_id = player_info.get("team")
-   next_three_fixtures= [current_game_week+1, current_game_week+2, current_game_week+3]
+   next_fixtures= [current_game_week,current_game_week+1, current_game_week+2]
    
    fixture_difficulty=[]
 
    for match in fixtures_metadata:
        game_week=match.get("event")
 
-       if game_week in next_three_fixtures:
+       if game_week in next_fixtures:
            away_team_id = match.get('team_a')
            home_team_id = match.get('team_h')
 

--- a/src/models.py
+++ b/src/models.py
@@ -65,8 +65,9 @@ class PlanningPlayerDetail(BaseModel):
     player_news:str= Field(..., description="The latest news on player, example injury news")
     team_name:str= Field(..., description="The name of the player's club")
     photo_url:str= Field(..., description="The full url for player image")
-    next_3_fixtures: list= Field(..., description="list of next 3 fixtures")
+    upcoming_fixtures: list= Field(..., description="list of next 3 fixtures")
     defensive_contribution_per_90:Optional[float] = Field(default=None, description="Average count of player's defensive actions")
+    start_certainty:Optional[str] = Field(default=None, description="User defined metric for how certain a player is of starting next gameweek")
     goals_scored: int
     assists: int
 

--- a/src/models.py
+++ b/src/models.py
@@ -9,21 +9,32 @@ class PlayerDetail(BaseModel):
     is_vice_captain:bool
 
     code:int
-    photo_url:str = Field(..., description="The full url for player image")
+    photo_url:str= Field(..., description="The full url for player image")
     web_name:str= Field(..., description="The name of player's club")
-    now_cost:int= Field(...,description="The player's current price x 10")
+    now_cost:Optional[int]= Field(default=None,description="The player's current price x 10")
     position:str= Field(..., description="The player's position(GKP, DEF, MID, FWD)")
     team_name:str= Field(..., description="The name of the player's club")
-    event_points:int= Field(..., description="The player's points for current gameweek")
+    event_points:Optional[int]= Field(default=None, description="The player's points for current gameweek")
     minutes:Optional[int]
     points_per_game:Optional[float]
+    defensive_contribution_per_90:Optional[float] = Field(default=None, description="Average count of player's defensive actions")
+    defensive_contribution:Optional[float] = Field(default=None, description="A count of players defensive actions")
 
-    player_status:str = Field(..., description=" Dashboard feature for player availability example: 'Available', 'Doubtful', 'Injured'")
-    player_news:str = Field(..., description="The latest news on player, example injury news")
-    start_certainty:str = Field(..., description="User defined metric for how certain a player is of starting next gameweek")
+    player_status:Optional[str] = Field(default=None, description=" Dashboard feature for player availability example: 'Available', 'Doubtful', 'Injured'")
+    player_news:Optional[str] = Field(default=None, description="The latest news on player, example injury news")
+    start_certainty:Optional[str] = Field(default=None, description="User defined metric for how certain a player is of starting next gameweek")
 
-    next_opponent_name:str = Field(..., description="Club name of nex fixture opponent")
-    next_opponent_difficulty:int = Field(..., description="Rating of fixture difficulty from 1-5")
+    next_opponent_name:Optional[str] = Field(default=None, description="Club name of next fixture opponent")
+    next_opponent_difficulty:Optional[int] = Field(default=None, description="Rating of fixture difficulty from 1-5")
+    goals_scored: int
+    assists: int
+
+    opponent: Optional[str] = Field(None, description="Opponent for a past gameweek")
+    player_team_score: Optional[int] = Field(None)
+    opponent_team_score: Optional[int] = Field(None)
+    bps:Optional[int]= Field(default=None, description="Bonus player System")
+
+
 
     class Config:
         from_attributes = True
@@ -40,21 +51,24 @@ class Fixture(BaseModel):
 
 class PlanningPlayerDetail(BaseModel):
 
-    element:int
-    position:int
+    element:int= Field(..., description="The player's unique FPL ID")
+    position:str= Field(..., description="The player's position(GKP, DEF, MID, FWD)")
     is_captain:bool
     is_vice_captain:bool
 
     first_name:str
     second_name:str
-    web_name:str
+    web_name:str= Field(..., description="The name of player's club")
 
-    player_status:str
-    player_news:str
-    team_name:str
-    position:str
-    photo_url:str
-    next_3_fixtures: list
+    player_status:str= Field(..., description=" Dashboard feature for player availability example: 'Available', 'Doubtful', 'Injured'")
+    now_cost:int= Field(...,description="The player's current price x 10")
+    player_news:str= Field(..., description="The latest news on player, example injury news")
+    team_name:str= Field(..., description="The name of the player's club")
+    photo_url:str= Field(..., description="The full url for player image")
+    next_3_fixtures: list= Field(..., description="list of next 3 fixtures")
+    defensive_contribution_per_90:Optional[float] = Field(default=None, description="Average count of player's defensive actions")
+    goals_scored: int
+    assists: int
 
 
 class PlanningViewResponse(BaseModel):

--- a/src/models.py
+++ b/src/models.py
@@ -29,7 +29,6 @@ class PlayerDetail(BaseModel):
         from_attributes = True
 
 class TeamDetailsResponse(BaseModel):
-
     players: List[PlayerDetail]
 
 
@@ -37,3 +36,29 @@ class Fixture(BaseModel):
     opponent_name:str
     difficulty:int
     is_home:bool
+
+
+class PlanningPlayerDetail(BaseModel):
+
+    element:int
+    position:int
+    is_captain:bool
+    is_vice_captain:bool
+
+    first_name:str
+    second_name:str
+    web_name:str
+
+    player_status:str
+    player_news:str
+    team_name:str
+    position:str
+    photo_url:str
+    next_3_fixtures: list
+
+
+class PlanningViewResponse(BaseModel):
+    view_mode: str = "planning"
+    requested_gameweek:int
+    roster_gameweek: int
+    players: list[PlanningPlayerDetail]


### PR DESCRIPTION
What was the problem?
The application had a single, static view for all gameweeks. This caused critical data trust issues, such as showing live player statuses for historical gameweeks or not providing enough forward-looking data for future gameweeks.

What was the solution?
This PR refactors the entire application to support three distinct, context-aware views:
Planning View: For future gameweeks, focusing on fixtures and decision-making.
Live View: A lean "Performance Dashboard" for the current gameweek, focusing on points and BPS.
Historical Snapshot: For past gameweeks, showing only the accurate, historical result.
The backend was refactored into a three-state machine, and the frontend was updated to dynamically render the correct UI for each state.

How was this tested?
The feature was tested locally using the two-terminal workflow. All three view modes (past, present, and future) were confirmed to render the correct data in both the main table and the player modal.